### PR TITLE
Add an option to disable rendering of items in pipes

### DIFF
--- a/src/main/java/de/ellpeck/prettypipes/Config.java
+++ b/src/main/java/de/ellpeck/prettypipes/Config.java
@@ -1,0 +1,32 @@
+package de.ellpeck.prettypipes;
+
+import net.minecraftforge.common.ForgeConfigSpec;
+import net.minecraftforge.fml.ModLoadingContext;
+import net.minecraftforge.fml.config.ModConfig;
+import org.apache.commons.lang3.tuple.Pair;
+
+public class Config {
+    public static class Client
+    {
+        public final ForgeConfigSpec.BooleanValue pipeRender;
+
+        public Client(ForgeConfigSpec.Builder builder)
+        {
+            builder.comment("Should items be rendered inside pipes?");
+            pipeRender = builder.define("Pipe Rendering", true);
+        }
+    }
+
+    public static final ForgeConfigSpec CLIENT_SPEC;
+    public static final Client CLIENT;
+    static {
+        {
+            final Pair<Client, ForgeConfigSpec> specPair = new ForgeConfigSpec.Builder().configure(Client::new);
+            CLIENT = specPair.getLeft();
+            CLIENT_SPEC = specPair.getRight();
+        }
+    }
+    public static void register() {
+        ModLoadingContext.get().registerConfig(ModConfig.Type.CLIENT, CLIENT_SPEC);
+    }
+}

--- a/src/main/java/de/ellpeck/prettypipes/PrettyPipes.java
+++ b/src/main/java/de/ellpeck/prettypipes/PrettyPipes.java
@@ -11,6 +11,8 @@ public final class PrettyPipes {
     public static final String ID = "prettypipes";
 
     public PrettyPipes() {
+        Config.register();
+
         var bus = FMLJavaModLoadingContext.get().getModEventBus();
         bus.addListener(Registry::setup);
         DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> bus.addListener(Registry.Client::setup));

--- a/src/main/java/de/ellpeck/prettypipes/pipe/PipeRenderer.java
+++ b/src/main/java/de/ellpeck/prettypipes/pipe/PipeRenderer.java
@@ -1,6 +1,7 @@
 package de.ellpeck.prettypipes.pipe;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import de.ellpeck.prettypipes.Config;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.ItemBlockRenderTypes;
 import net.minecraft.client.renderer.MultiBufferSource;
@@ -21,7 +22,7 @@ public class PipeRenderer implements BlockEntityRenderer<PipeBlockEntity> {
 
     @Override
     public void render(PipeBlockEntity tile, float partialTicks, PoseStack matrixStack, MultiBufferSource source, int light, int overlay) {
-        if (!tile.getItems().isEmpty()) {
+        if (!tile.getItems().isEmpty() && Config.CLIENT.pipeRender.get()) {
             matrixStack.pushPose();
             var tilePos = tile.getBlockPos();
             matrixStack.translate(-tilePos.getX(), -tilePos.getY(), -tilePos.getZ());


### PR DESCRIPTION
I was proposing to a friend to use Pretty Pipes instead of Simple Storage Network because I prefer it. Their response was "I can never use that, it draws the items inside the pipes so that means it will cause lag". So I added a config option to turn off item rendering.