### PR TITLE
Fix performance issue in getOrderedNetworkItems()

### DIFF
--- a/src/main/java/de/ellpeck/prettypipes/network/PipeNetwork.java
+++ b/src/main/java/de/ellpeck/prettypipes/network/PipeNetwork.java
@@ -349,7 +349,7 @@ public class PipeNetwork extends SavedData implements GraphListener<BlockPos, Ne
                     continue;
                 var location = new NetworkLocation(dest, dir);
                 if (!location.isEmpty(this.level))
-                    info.add(location);
+                    info.putIfAbsent(handler, location);
             }
         }
         this.endProfile();

--- a/src/main/java/de/ellpeck/prettypipes/network/PipeNetwork.java
+++ b/src/main/java/de/ellpeck/prettypipes/network/PipeNetwork.java
@@ -334,12 +334,11 @@ public class PipeNetwork extends SavedData implements GraphListener<BlockPos, Ne
         }
         return total;
     }
-
     public List<NetworkLocation> getOrderedNetworkItems(BlockPos node) {
         if (!this.isNode(node))
             return Collections.emptyList();
         this.startProfile("get_network_items");
-        List<NetworkLocation> info = new ArrayList<>();
+        Map<IItemHandler, NetworkLocation> info = new LinkedHashMap<>();
         for (var dest : this.getOrderedNetworkNodes(node)) {
             if (!this.level.isLoaded(dest))
                 continue;
@@ -348,16 +347,13 @@ public class PipeNetwork extends SavedData implements GraphListener<BlockPos, Ne
                 var handler = pipe.getItemHandler(dir);
                 if (handler == null || !pipe.canNetworkSee(dir, handler))
                     continue;
-                // check if this handler already exists (double-connected pipes, double chests etc.)
-                if (info.stream().anyMatch(l -> handler.equals(l.getItemHandler(this.level))))
-                    continue;
                 var location = new NetworkLocation(dest, dir);
                 if (!location.isEmpty(this.level))
                     info.add(location);
             }
         }
         this.endProfile();
-        return info;
+        return new ArrayList<>(info.values());
     }
 
     public void createNetworkLock(NetworkLock lock) {


### PR DESCRIPTION
I've noticed that my server is having low tps problem, despite good hardware. After some debugging, I've concluded that lag is caused by PipeNetwork.getOrderedNetworkItems() function.

A simple change could be made to improve its performance and fix the lag.
