### PR TITLE
Quick and dirty workaround for functional storage drawers

### DIFF
--- a/src/main/java/de/ellpeck/prettypipes/pipe/PipeBlockEntity.java
+++ b/src/main/java/de/ellpeck/prettypipes/pipe/PipeBlockEntity.java
@@ -236,6 +236,13 @@ public class PipeBlockEntity extends BlockEntity implements MenuProvider, IPipeC
                         // if the container can store more than 64 items in this slot, then it's likely
                         // a barrel or similar, meaning that the slot limit matters more than the max stack size
                         var limit = handler.getSlotLimit(i);
+                        // a quick and dirty hack for Functional Storage. given a drawer with a void upgrade,
+                        // it adds a separate slot at the end that returns MAX_VALUE from a call to getSlotLimit().
+                        // this hack avoids a possible integer overflow when modifying totalSpace below.
+                        if (limit == Integer.MAX_VALUE) {
+                            totalSpace = limit;
+                            break;
+                        }
                         if (limit > 64)
                             maxStackSize = limit;
                         copy.setCount(maxStackSize);


### PR DESCRIPTION
Sorry if this PR is subpar, as I have not touched anything Java in about 15 years.

Finally tried to address a long-standing bug in mod interaction between PrettyPipes and Functional Storage: sporadic inability to insert into functional storage drawers when a void upgrade is installed.

If my code reading is correct - this is caused in integer overflow [here](https://github.com/Ellpeck/PrettyPipes/blob/main/src/main/java/de/ellpeck/prettypipes/pipe/PipeBlockEntity.java#L245), as Functional Storage adds a pseudo-slot to its inventory when voiding upgrade is installed, which has a slot limit of Integer.MAX_VALUE.

More correct way to handle this is to use saturating math, or check for overflows explicitly. But my Java is way too rusty to remember how to do that, sorry.

Closes #224
Related to discussion in #131