### PR TITLE
Add JEI ghost ingredient handling for filters and crafting slots Fixing #213

### DIFF
--- a/src/main/java/de/ellpeck/prettypipes/Registry.java
+++ b/src/main/java/de/ellpeck/prettypipes/Registry.java
@@ -225,6 +225,7 @@ public final class Registry {
         registrar.playBidirectional(PacketButton.TYPE, PacketButton.CODEC, PacketButton::onMessage);
         registrar.playBidirectional(PacketCraftingModuleTransfer.TYPE, PacketCraftingModuleTransfer.CODEC, PacketCraftingModuleTransfer::onMessage);
         registrar.playBidirectional(PacketGhostSlot.TYPE, PacketGhostSlot.CODEC, PacketGhostSlot::onMessage);
+        registrar.playToServer(PacketFilterSlot.TYPE, PacketFilterSlot.CODEC, PacketFilterSlot::onMessage);
         registrar.playBidirectional(PacketNetworkItems.TYPE, PacketNetworkItems.CODEC, PacketNetworkItems::onMessage);
         registrar.playBidirectional(PacketRequest.TYPE, PacketRequest.CODEC, PacketRequest::onMessage);
     }

--- a/src/main/java/de/ellpeck/prettypipes/compat/jei/JEICraftingTerminalGhostIngredients.java
+++ b/src/main/java/de/ellpeck/prettypipes/compat/jei/JEICraftingTerminalGhostIngredients.java
@@ -1,0 +1,70 @@
+package de.ellpeck.prettypipes.compat.jei;
+
+import de.ellpeck.prettypipes.packets.PacketGhostSlot;
+import de.ellpeck.prettypipes.terminal.CraftingTerminalBlockEntity;
+import de.ellpeck.prettypipes.terminal.containers.CraftingTerminalGui;
+import mezz.jei.api.gui.handlers.IGhostIngredientHandler;
+import mezz.jei.api.ingredients.ITypedIngredient;
+import net.minecraft.client.renderer.Rect2i;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.network.PacketDistributor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class JEICraftingTerminalGhostIngredients implements IGhostIngredientHandler<CraftingTerminalGui> {
+
+
+    @Override
+    public <I> List<Target<I>> getTargetsTyped(CraftingTerminalGui gui, ITypedIngredient<I> ingredient, boolean doStart) {
+        var targetList = new ArrayList<IGhostIngredientHandler.Target<I>>();
+        for (int i=0;i<9;i++) {
+            var curTarget = new GhostSlotTarget(i,gui);
+            targetList.add((Target<I>) curTarget);
+        }
+        return targetList;
+    }
+
+    @Override
+    public void onComplete() {
+
+    }
+
+
+    public static class GhostSlotTarget implements IGhostIngredientHandler.Target<ItemStack> {
+
+        private final int curSlotIndex;
+        private final CraftingTerminalGui gui;
+        private Slot curSlot;
+        public GhostSlotTarget(int curSlotIndex, CraftingTerminalGui gui) {
+            this.curSlotIndex = curSlotIndex;
+            this.gui = gui;
+            this.curSlot = gui.getMenu().getSlot(curSlotIndex+1);
+        }
+
+        @Override
+        public Rect2i getArea() {
+
+            return new Rect2i(gui.getGuiLeft()+curSlot.x, gui.getGuiTop()+curSlot.y, 16, 16);
+        }
+
+        @Override
+        public void accept(ItemStack ingredient) {
+            if(gui.getMenu().tile instanceof CraftingTerminalBlockEntity craftingTerminalBlockEntity) {
+                List<PacketGhostSlot.Entry> stacks = new ArrayList<>();
+                for(int i=0;i<craftingTerminalBlockEntity.ghostItems.getSlots();i++)
+                {
+                    if(i!=curSlotIndex)
+                        stacks.add(i,new PacketGhostSlot.Entry(Optional.of(List.of(craftingTerminalBlockEntity.ghostItems.getStackInSlot(i))),Optional.empty()));
+                    else {
+                        stacks.add(i,new PacketGhostSlot.Entry(Optional.of(List.of(ingredient)),Optional.empty()));
+                    }
+
+                }
+                PacketDistributor.sendToServer(new PacketGhostSlot(craftingTerminalBlockEntity.getBlockPos(), stacks));
+            }
+        }
+    }
+}

--- a/src/main/java/de/ellpeck/prettypipes/compat/jei/JEIFilterGhostIngredients.java
+++ b/src/main/java/de/ellpeck/prettypipes/compat/jei/JEIFilterGhostIngredients.java
@@ -1,0 +1,58 @@
+package de.ellpeck.prettypipes.compat.jei;
+
+import de.ellpeck.prettypipes.misc.FilterSlot;
+import de.ellpeck.prettypipes.misc.ItemFilter;
+import de.ellpeck.prettypipes.packets.PacketFilterSlot;
+import de.ellpeck.prettypipes.pipe.containers.AbstractPipeContainer;
+import de.ellpeck.prettypipes.pipe.containers.AbstractPipeGui;
+import de.ellpeck.prettypipes.pipe.modules.filter.FilterIncreaseModuleGui;
+import mezz.jei.api.gui.handlers.IGhostIngredientHandler;
+import mezz.jei.api.ingredients.ITypedIngredient;
+import net.minecraft.client.renderer.Rect2i;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.network.PacketDistributor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class JEIFilterGhostIngredients implements IGhostIngredientHandler<AbstractPipeGui> {
+    @Override
+    public <I> List<Target<I>> getTargetsTyped(AbstractPipeGui gui, ITypedIngredient<I> ingredient, boolean doStart) {
+        var targetList = new ArrayList<Target<I>>();
+        if(gui.getMenu() instanceof ItemFilter.IFilteredContainer container) {
+
+            for (Slot slot : gui.getMenu().slots) {
+                if (slot instanceof FilterSlot) {
+                    targetList.add((Target<I>) new GhostTarget(gui, slot));
+                }
+            }
+
+        }
+        return targetList;
+    }
+
+    @Override
+    public void onComplete() {
+
+    }
+
+    public static class GhostTarget implements IGhostIngredientHandler.Target<ItemStack> {
+        private final Slot slot;
+        private final AbstractPipeGui gui;
+        public GhostTarget(AbstractPipeGui gui,Slot slot) {
+            this.slot = slot;
+            this.gui = gui;
+        }
+        @Override
+        public Rect2i getArea() {
+            return new Rect2i(gui.getGuiLeft()+slot.x, gui.getGuiTop()+slot.y, 16, 16);
+        }
+
+        @Override
+        public void accept(ItemStack ingredient) {
+            if (ingredient.isEmpty() || !(slot instanceof FilterSlot)) return;
+            PacketDistributor.sendToServer(new PacketFilterSlot(slot.index, ingredient));
+        }
+    }
+}

--- a/src/main/java/de/ellpeck/prettypipes/compat/jei/JEIPrettyPipesPlugin.java
+++ b/src/main/java/de/ellpeck/prettypipes/compat/jei/JEIPrettyPipesPlugin.java
@@ -2,6 +2,9 @@ package de.ellpeck.prettypipes.compat.jei;
 
 import de.ellpeck.prettypipes.PrettyPipes;
 import de.ellpeck.prettypipes.misc.PlayerPrefs;
+import de.ellpeck.prettypipes.pipe.containers.AbstractPipeGui;
+import de.ellpeck.prettypipes.pipe.modules.filter.FilterIncreaseModuleGui;
+import de.ellpeck.prettypipes.terminal.containers.CraftingTerminalGui;
 import de.ellpeck.prettypipes.terminal.containers.ItemTerminalGui;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
@@ -66,6 +69,8 @@ public class JEIPrettyPipesPlugin implements IModPlugin {
                 return ret;
             }
         });
+        registration.addGhostIngredientHandler(CraftingTerminalGui.class,new JEICraftingTerminalGhostIngredients());
+        registration.addGhostIngredientHandler(AbstractPipeGui.class,new JEIFilterGhostIngredients());
     }
 
     @SubscribeEvent

--- a/src/main/java/de/ellpeck/prettypipes/misc/FilterSlot.java
+++ b/src/main/java/de/ellpeck/prettypipes/misc/FilterSlot.java
@@ -27,8 +27,7 @@ public class FilterSlot extends SlotItemHandler {
         return false;
     }
 
-    private void slotClick(AbstractContainerMenu menu) {
-        var heldStack = menu.getCarried();
+    public void slotClick(AbstractContainerMenu menu, ItemStack heldStack) {
         var stackInSlot = this.getItem();
 
         if (!stackInSlot.isEmpty() && heldStack.isEmpty()) {
@@ -39,6 +38,10 @@ public class FilterSlot extends SlotItemHandler {
                 s.setCount(1);
             this.set(s);
         }
+    }
+    private void slotClick(AbstractContainerMenu menu) {
+        var heldStack = menu.getCarried();
+        slotClick(menu, heldStack);
     }
 
     @Override

--- a/src/main/java/de/ellpeck/prettypipes/packets/PacketFilterSlot.java
+++ b/src/main/java/de/ellpeck/prettypipes/packets/PacketFilterSlot.java
@@ -1,0 +1,39 @@
+package de.ellpeck.prettypipes.packets;
+
+import de.ellpeck.prettypipes.PrettyPipes;
+import de.ellpeck.prettypipes.Utility;
+import de.ellpeck.prettypipes.items.IModule;
+import de.ellpeck.prettypipes.misc.FilterSlot;
+import de.ellpeck.prettypipes.pipe.PipeBlockEntity;
+import mezz.jei.api.helpers.ICodecHelper;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.network.handling.IPayloadContext;
+import org.apache.logging.log4j.LogManager;
+
+import java.util.ArrayList;
+
+public record PacketFilterSlot(int slotIndex, ItemStack stack) implements CustomPacketPayload {
+    public static final Type<PacketFilterSlot> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(PrettyPipes.ID, "ghost_filter_slot"));
+    public static final StreamCodec<RegistryFriendlyByteBuf, PacketFilterSlot> CODEC = StreamCodec.composite(
+            ByteBufCodecs.INT, PacketFilterSlot::slotIndex,
+            ItemStack.STREAM_CODEC, PacketFilterSlot::stack,
+            PacketFilterSlot::new);
+
+    @Override
+    public Type<? extends CustomPacketPayload> type() {
+        return PacketFilterSlot.TYPE;
+    }
+    public static void onMessage(PacketFilterSlot message, IPayloadContext ctx) {
+        var player = ctx.player();
+        if(player.containerMenu.slots.get(message.slotIndex()) instanceof FilterSlot filterSlot){
+            filterSlot.slotClick(player.containerMenu, message.stack());
+        }
+
+    }
+}


### PR DESCRIPTION
### Description

This pull request introduces support for JEI ghost ingredients in filters and crafting slots. It includes:

- New classes: `JEIFilterGhostIngredients` and `JEICraftingTerminalGhostIngredients` to handle ghost ingredient features.
- Implementation of `PacketFilterSlot` for server-side updates of filter slots.
- Update to `FilterSlot` with a public `slotClick` method to facilitate packet communication.
- Registration of JEI ghost ingredient handlers in the `JEIPrettyPipesPlugin`.
