### PR TITLE
Implement ghost item drag-and-drop handling

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ neo_version_range=[21.1.0,)
 # The loader version range can only use the major version of FML as bounds
 loader_version_range=[4,)
 
-jei_version=19.18.3.204
+jei_version=19.25.0.323
 jgt_version=1.5.2
 jheaps_version=0.14
 apfloat_version=1.10.1

--- a/src/main/java/de/ellpeck/prettypipes/Registry.java
+++ b/src/main/java/de/ellpeck/prettypipes/Registry.java
@@ -225,6 +225,7 @@ public final class Registry {
         registrar.playBidirectional(PacketButton.TYPE, PacketButton.CODEC, PacketButton::onMessage);
         registrar.playBidirectional(PacketCraftingModuleTransfer.TYPE, PacketCraftingModuleTransfer.CODEC, PacketCraftingModuleTransfer::onMessage);
         registrar.playBidirectional(PacketGhostSlot.TYPE, PacketGhostSlot.CODEC, PacketGhostSlot::onMessage);
+        registrar.playToServer(PacketFilterSlot.TYPE, PacketFilterSlot.CODEC, PacketFilterSlot::onMessage);
         registrar.playBidirectional(PacketNetworkItems.TYPE, PacketNetworkItems.CODEC, PacketNetworkItems::onMessage);
         registrar.playBidirectional(PacketRequest.TYPE, PacketRequest.CODEC, PacketRequest::onMessage);
     }

--- a/src/main/java/de/ellpeck/prettypipes/compat/jei/JEICraftingTerminalGhostIngredients.java
+++ b/src/main/java/de/ellpeck/prettypipes/compat/jei/JEICraftingTerminalGhostIngredients.java
@@ -1,0 +1,66 @@
+package de.ellpeck.prettypipes.compat.jei;
+
+import de.ellpeck.prettypipes.packets.PacketGhostSlot;
+import de.ellpeck.prettypipes.terminal.CraftingTerminalBlockEntity;
+import de.ellpeck.prettypipes.terminal.containers.CraftingTerminalGui;
+import mezz.jei.api.gui.handlers.IGhostIngredientHandler;
+import mezz.jei.api.ingredients.ITypedIngredient;
+import net.minecraft.client.renderer.Rect2i;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.network.PacketDistributor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class JEICraftingTerminalGhostIngredients implements IGhostIngredientHandler<CraftingTerminalGui>{
+
+
+    @Override
+    public <I> List<Target<I>> getTargetsTyped(CraftingTerminalGui gui, ITypedIngredient<I> ingredient, boolean doStart) {
+        var targetList = new ArrayList<IGhostIngredientHandler.Target<I>>();
+        for(int i=0;i<=9;i++) {
+            var currentTarget = new GhostSlotTarget(i, gui);
+            targetList.add((Target<I>) currentTarget);
+        }
+        return targetList;
+    }
+
+    @Override
+    public void onComplete() {
+
+    }
+
+    public static class GhostSlotTarget implements IGhostIngredientHandler.Target<ItemStack> {
+        private final int curSlotIndex;
+        private final CraftingTerminalGui gui;
+        private Slot curSlot;
+
+        public GhostSlotTarget(int curSlotIndex, CraftingTerminalGui gui) {
+            this.curSlotIndex = curSlotIndex;
+            this.gui = gui;
+            this.curSlot = gui.getMenu().getSlot(curSlotIndex+1);
+        }
+
+        @Override
+        public Rect2i getArea() {
+            return new Rect2i(gui.getGuiLeft() + curSlot.x, gui.getGuiTop() + curSlot.y, 16, 16);
+        }
+
+        @Override
+        public void accept(ItemStack ingredient) {
+            if(gui.getMenu().tile instanceof CraftingTerminalBlockEntity craftingTerminalBlockEntity) {
+                ItemStack ghostStack = ingredient.copyWithCount(1);
+                List<PacketGhostSlot.Entry> stacks = new ArrayList<>();
+                for(int i=0;i < craftingTerminalBlockEntity.craftItems.getSlots();i++) {
+                    if(i != curSlotIndex)
+                        stacks.add(i, new PacketGhostSlot.Entry(Optional.of(List.of(craftingTerminalBlockEntity.ghostItems.getStackInSlot(i))),Optional.empty()));
+                    else
+                        stacks.add(i,new PacketGhostSlot.Entry(Optional.of(List.of(ghostStack)),Optional.empty()));
+                }
+                PacketDistributor.sendToServer(new PacketGhostSlot(craftingTerminalBlockEntity.getBlockPos(), stacks));
+            }
+        }
+    }
+}

--- a/src/main/java/de/ellpeck/prettypipes/compat/jei/JEICraftingTerminalGuiElementHandler.java
+++ b/src/main/java/de/ellpeck/prettypipes/compat/jei/JEICraftingTerminalGuiElementHandler.java
@@ -1,0 +1,48 @@
+package de.ellpeck.prettypipes.compat.jei;
+
+import de.ellpeck.prettypipes.misc.ItemTerminalWidget;
+import de.ellpeck.prettypipes.terminal.CraftingTerminalBlockEntity;
+import de.ellpeck.prettypipes.terminal.containers.ItemTerminalGui;
+import mezz.jei.api.gui.builder.IClickableIngredientFactory;
+import mezz.jei.api.gui.handlers.IGuiContainerHandler;
+import mezz.jei.api.runtime.IClickableIngredient;
+import net.minecraft.client.renderer.Rect2i;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class JEICraftingTerminalGuiElementHandler implements IGuiContainerHandler<ItemTerminalGui> {
+    @Override
+    public List<Rect2i> getGuiExtraAreas(ItemTerminalGui containerScreen) {
+        List<Rect2i> ret = new ArrayList<>();
+        // sorting buttons
+        ret.add(new Rect2i(containerScreen.getGuiLeft() - 22, containerScreen.getGuiTop(), 22, 64));
+        // crafting hud
+        if (containerScreen.currentlyCrafting != null && !containerScreen.currentlyCrafting.isEmpty())
+            ret.add(new Rect2i(containerScreen.getGuiLeft() + containerScreen.getXSize(), containerScreen.getGuiTop() + 4, 65, 89));
+        return ret;
+    }
+
+    @Override
+    public Optional<? extends IClickableIngredient<?>> getClickableIngredientUnderMouse(IClickableIngredientFactory builder, ItemTerminalGui containerScreen, double mouseX, double mouseY) {
+        var child = containerScreen.getChildAt(mouseX, mouseY);
+        var curSlot = containerScreen.getSlotUnderMouse();
+        // Exposes terminal widget or ghost crafting ingredient
+        if(child.isPresent()) {
+            var childSlot = child.get();
+            if(childSlot instanceof ItemTerminalWidget widget) {
+                return builder.createBuilder(widget.stack).buildWithArea(widget.getX(),widget.getY(),widget.getWidth(),widget.getHeight());
+            }
+        } else if(curSlot != null && curSlot.index > 0 && curSlot.index <= 9 ) {
+            // Exposes ghost crafting ingredient when present
+            if(containerScreen.getMenu().tile instanceof CraftingTerminalBlockEntity craftingTerminal) {
+                if(craftingTerminal.isGhostItem(curSlot.index-1)) {
+                    var stack = craftingTerminal.ghostItems.getStackInSlot(curSlot.index-1);
+                    return builder.createBuilder(stack).buildWithArea(curSlot.x,curSlot.y,18,18);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/de/ellpeck/prettypipes/compat/jei/JEIFilterGhostIngredients.java
+++ b/src/main/java/de/ellpeck/prettypipes/compat/jei/JEIFilterGhostIngredients.java
@@ -1,0 +1,56 @@
+package de.ellpeck.prettypipes.compat.jei;
+
+import de.ellpeck.prettypipes.misc.FilterSlot;
+import de.ellpeck.prettypipes.misc.ItemFilter;
+import de.ellpeck.prettypipes.packets.PacketFilterSlot;
+import de.ellpeck.prettypipes.pipe.containers.AbstractPipeGui;
+import mezz.jei.api.gui.handlers.IGhostIngredientHandler;
+import mezz.jei.api.ingredients.ITypedIngredient;
+import net.minecraft.client.renderer.Rect2i;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.network.PacketDistributor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class JEIFilterGhostIngredients implements IGhostIngredientHandler<AbstractPipeGui> {
+    @Override
+    public <I> List<Target<I>> getTargetsTyped(AbstractPipeGui gui, ITypedIngredient<I> ingredient, boolean doStart) {
+        var targetList = new ArrayList<Target<I>>();
+        if(gui.getMenu() instanceof ItemFilter.IFilteredContainer container) {
+
+            for (Slot slot : gui.getMenu().slots) {
+                if (slot instanceof FilterSlot) {
+                    targetList.add((Target<I>) new GhostTarget(gui, slot));
+                }
+            }
+
+        }
+        return targetList;
+    }
+
+    @Override
+    public void onComplete() {
+
+    }
+
+    public static class GhostTarget implements IGhostIngredientHandler.Target<ItemStack> {
+        private final Slot slot;
+        private final AbstractPipeGui gui;
+        public GhostTarget(AbstractPipeGui gui,Slot slot) {
+            this.slot = slot;
+            this.gui = gui;
+        }
+        @Override
+        public Rect2i getArea() {
+            return new Rect2i(gui.getGuiLeft()+slot.x, gui.getGuiTop()+slot.y, 16, 16);
+        }
+
+        @Override
+        public void accept(ItemStack ingredient) {
+            if (ingredient.isEmpty() || !(slot instanceof FilterSlot)) return;
+            PacketDistributor.sendToServer(new PacketFilterSlot(slot.index, ingredient));
+        }
+    }
+}

--- a/src/main/java/de/ellpeck/prettypipes/compat/jei/JEIPrettyPipesPlugin.java
+++ b/src/main/java/de/ellpeck/prettypipes/compat/jei/JEIPrettyPipesPlugin.java
@@ -2,6 +2,8 @@ package de.ellpeck.prettypipes.compat.jei;
 
 import de.ellpeck.prettypipes.PrettyPipes;
 import de.ellpeck.prettypipes.misc.PlayerPrefs;
+import de.ellpeck.prettypipes.pipe.containers.AbstractPipeGui;
+import de.ellpeck.prettypipes.terminal.containers.CraftingTerminalGui;
 import de.ellpeck.prettypipes.terminal.containers.ItemTerminalGui;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
@@ -54,19 +56,11 @@ public class JEIPrettyPipesPlugin implements IModPlugin {
 
     @Override
     public void registerGuiHandlers(IGuiHandlerRegistration registration) {
-        registration.addGuiContainerHandler(ItemTerminalGui.class, new IGuiContainerHandler<>() {
-            @Override
-            public List<Rect2i> getGuiExtraAreas(ItemTerminalGui containerScreen) {
-                List<Rect2i> ret = new ArrayList<>();
-                // sorting buttons
-                ret.add(new Rect2i(containerScreen.getGuiLeft() - 22, containerScreen.getGuiTop(), 22, 64));
-                // crafting hud
-                if (containerScreen.currentlyCrafting != null && !containerScreen.currentlyCrafting.isEmpty())
-                    ret.add(new Rect2i(containerScreen.getGuiLeft() + containerScreen.getXSize(), containerScreen.getGuiTop() + 4, 65, 89));
-                return ret;
-            }
-        });
+        registration.addGuiContainerHandler(ItemTerminalGui.class, new JEICraftingTerminalGuiElementHandler());
+        registration.addGhostIngredientHandler(CraftingTerminalGui.class, new JEICraftingTerminalGhostIngredients());
+        registration.addGhostIngredientHandler(AbstractPipeGui.class, new JEIFilterGhostIngredients());
     }
+
 
     @SubscribeEvent
     public void onInitGui(ScreenEvent.Init.Post event) {

--- a/src/main/java/de/ellpeck/prettypipes/misc/FilterSlot.java
+++ b/src/main/java/de/ellpeck/prettypipes/misc/FilterSlot.java
@@ -27,14 +27,21 @@ public class FilterSlot extends SlotItemHandler {
         return false;
     }
 
+    public void slotClick(AbstractContainerMenu menu, ItemStack itemStack) {
+        this.slotClickMethod(this.getItem(), itemStack);
+    }
     private void slotClick(AbstractContainerMenu menu) {
         var heldStack = menu.getCarried();
         var stackInSlot = this.getItem();
 
-        if (!stackInSlot.isEmpty() && heldStack.isEmpty()) {
+        slotClickMethod(stackInSlot, heldStack);
+    }
+
+    private void slotClickMethod(ItemStack stackInSlot, ItemStack itemStack) {
+        if (!stackInSlot.isEmpty() && itemStack.isEmpty()) {
             this.set(ItemStack.EMPTY);
-        } else if (!heldStack.isEmpty()) {
-            var s = heldStack.copy();
+        } else if (!itemStack.isEmpty()) {
+            var s = itemStack.copy();
             if (this.onlyOneItem)
                 s.setCount(1);
             this.set(s);

--- a/src/main/java/de/ellpeck/prettypipes/packets/PacketFilterSlot.java
+++ b/src/main/java/de/ellpeck/prettypipes/packets/PacketFilterSlot.java
@@ -1,0 +1,31 @@
+package de.ellpeck.prettypipes.packets;
+
+import de.ellpeck.prettypipes.PrettyPipes;
+import de.ellpeck.prettypipes.misc.FilterSlot;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.network.handling.IPayloadContext;
+
+public record PacketFilterSlot(int slotIndex, ItemStack stack) implements CustomPacketPayload {
+    public static final Type<PacketFilterSlot> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(PrettyPipes.ID, "ghost_filter_slot"));
+    public static final StreamCodec<RegistryFriendlyByteBuf, PacketFilterSlot> CODEC = StreamCodec.composite(
+            ByteBufCodecs.INT, PacketFilterSlot::slotIndex,
+            ItemStack.STREAM_CODEC, PacketFilterSlot::stack,
+            PacketFilterSlot::new);
+
+    @Override
+    public Type<? extends CustomPacketPayload> type() {
+        return PacketFilterSlot.TYPE;
+    }
+    public static void onMessage(PacketFilterSlot message, IPayloadContext ctx) {
+        var player = ctx.player();
+        if(player.containerMenu.slots.get(message.slotIndex()) instanceof FilterSlot filterSlot){
+            filterSlot.slotClick(player.containerMenu, message.stack());
+        }
+
+    }
+}

--- a/src/main/java/de/ellpeck/prettypipes/terminal/containers/CraftingTerminalGui.java
+++ b/src/main/java/de/ellpeck/prettypipes/terminal/containers/CraftingTerminalGui.java
@@ -2,7 +2,10 @@ package de.ellpeck.prettypipes.terminal.containers;
 
 import com.mojang.blaze3d.platform.InputConstants;
 import de.ellpeck.prettypipes.PrettyPipes;
+import de.ellpeck.prettypipes.misc.ItemTerminalWidget;
 import de.ellpeck.prettypipes.packets.PacketButton;
+import de.ellpeck.prettypipes.packets.PacketGhostSlot;
+import de.ellpeck.prettypipes.terminal.CraftingTerminalBlockEntity;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.Tooltip;
@@ -10,16 +13,22 @@ import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.network.PacketDistributor;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 public class CraftingTerminalGui extends ItemTerminalGui {
 
     private static final ResourceLocation TEXTURE = ResourceLocation.fromNamespaceAndPath(PrettyPipes.ID, "textures/gui/crafting_terminal.png");
     private Button requestButton;
     private Button sendBackButton;
+    private ItemTerminalWidget draggedItem;
+    private boolean dragging;
 
     public CraftingTerminalGui(ItemTerminalContainer screenContainer, Inventory inv, Component titleIn) {
         super(screenContainer, inv, titleIn);
@@ -75,6 +84,68 @@ public class CraftingTerminalGui extends ItemTerminalGui {
                 continue;
             graphics.renderItem(ghost, slot.x, slot.y);
             graphics.renderItemDecorations(this.font, ghost, slot.x, slot.y, "0");
+        }
+    }
+
+    @Override
+    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        // Starts drag if clicked widget has item
+        if(button == 0 && this.draggedItem == null) {
+            this.getChildAt(mouseX,mouseY).ifPresent(child -> {
+                this.draggedItem = child instanceof ItemTerminalWidget widget && !widget.stack.isEmpty()? widget : null;
+            });
+        }
+        return super.mouseClicked(mouseX, mouseY, button);
+    }
+
+    @Override
+    public boolean mouseDragged(double mouseX, double mouseY, int i, double j, double k) {
+        // Makes sure clicks aren't counted as drags
+        if(this.draggedItem != null) {
+            double distance = j*j + k*k;
+            if(distance>2) {
+                dragging=true;
+            }
+        }
+        return super.mouseDragged(mouseX, mouseY, i, j, k);
+    }
+
+    @Override
+    public boolean mouseReleased(double mouseX, double mouseY, int button) {
+        Slot curSlot = this.getSlotUnderMouse();
+        if( draggedItem != null &&
+        !draggedItem.stack.isEmpty() &&
+        curSlot != null &&
+        curSlot.index >= 0 &&
+        curSlot.index <= 9) {
+            ItemStack ghostStack = draggedItem.stack.copyWithCount(1);
+            List<PacketGhostSlot.Entry> stacks = new ArrayList<>();
+            if(menu.tile instanceof CraftingTerminalBlockEntity craftingTerminalBlockEntity) {
+                for(int i=0; i< craftingTerminalBlockEntity.ghostItems.getSlots(); i++) {
+                    if(i!= curSlot.index-1)
+                    {
+                        stacks.add(i, new PacketGhostSlot.Entry(Optional.of(List.of(craftingTerminalBlockEntity.ghostItems.getStackInSlot(i))), Optional.empty()));
+                    } else {
+                        stacks.add(i, new PacketGhostSlot.Entry(Optional.of(List.of(ghostStack)), Optional.empty()));
+                    }
+                }
+                PacketDistributor.sendToServer(new PacketGhostSlot(craftingTerminalBlockEntity.getBlockPos(), stacks));
+            }
+        }
+        draggedItem = null;
+        dragging = false;
+        return super.mouseReleased(mouseX, mouseY, button);
+    }
+
+    @Override
+    public void render(GuiGraphics graphics, int mouseX, int mouseY, float partialTicks) {
+        super.render(graphics, mouseX, mouseY, partialTicks);
+        // Renders dragged item at cursor with z offset
+        if(dragging && draggedItem != null) {
+            graphics.pose().pushPose();
+            graphics.pose().translate(0, 0, 200);
+            graphics.renderItem(draggedItem.stack, mouseX-9, mouseY-9);
+            graphics.pose().popPose();
         }
     }
 


### PR DESCRIPTION
### Description

This pull request introduces handling drag and dropping ghost items to the Crafting Terminal interface and filters. It also introduces the ability for JEI to see the ghost items, for use of looking up recipe/uses.  It is a merged version of my previous PRs. With some added comments to try and match feel of existing code.
